### PR TITLE
Fix mpv crashes, improve recording playback/download, harden WebSocke…

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,179 @@
+# Troubleshooting Guide
+
+## Synology BC500 / Surveillance Station on Ubuntu 24.04
+
+---
+
+### Recommended Protocols (BC500 Cameras)
+
+| Use Case | Recommended Protocol | Notes |
+|---|---|---|
+| Live view | **WebSocket (Auto)** | Best latency; falls back automatically |
+| Live view (fallback) | MJPEG | Lower quality, very compatible |
+| Live view (fallback) | RTSP over HTTP | Good for NAT/firewall traversal |
+| Recording playback | Stream URL (automatic) | Handled internally by the app |
+
+**BC500 default codec is H.265 (HEVC).** If mpv cannot decode it in software,
+try enabling hardware decoding (the app uses `hwdec=auto` by default). If
+hardware decoding fails, see *H.264 vs H.265* below.
+
+---
+
+### HTTP 502 on WebSocket Live View
+
+**Symptom:**
+```
+websockets.exceptions.InvalidStatus: server rejected WebSocket connection: HTTP 502
+ERROR surveillance.services.ws_bridge: WebSocket bridge error
+```
+
+**Cause:** Surveillance Station's internal WebSocket proxy returned HTTP 502.
+This happens when:
+- The camera stream is not yet ready (camera booting, motion event just ended)
+- The NAS is under heavy load
+- Too many concurrent streams are open
+
+**What to do:**
+1. Wait 10–30 seconds and click the camera tile again.
+2. Try a different protocol in Settings → Camera → Stream protocol (MJPEG or RTSP over HTTP).
+3. Reboot the camera from Surveillance Station if the issue persists.
+4. Check *Control Panel → Log Center* on DSM for NAS-side errors.
+
+---
+
+### RTSP / mpv Playback Failure
+
+**Symptom:** Recording opens but stays black, or mpv log shows errors like:
+```
+TypeError: Tried to get/set mpv property using wrong format, or passed invalid value
+options/demuxer-lavf-probesize
+value: b'0'
+```
+
+**Cause:** A python-mpv version mismatch causes integer option `0` to be sent
+as a byte-string, which libmpv rejects for certain INT64 properties.
+
+**Fixed in this release.** The app now uses `safe_set_mpv_option()` which
+catches and logs any rejected mpv option without crashing.
+
+If you still see mpv errors:
+1. Update python-mpv: `pip install --upgrade python-mpv`
+2. Ensure libmpv is installed: `sudo apt install libmpv2` (Ubuntu 24.04)
+3. Run the app from a terminal and check the log output.
+
+---
+
+### Recording Playback: Video Never Starts
+
+**Symptom:** Player dialog opens but video area stays black. After ~7 seconds
+an error dialog appears: "Playback Failed".
+
+**Likely causes and fixes:**
+
+1. **Stream URL expired** — The URL is valid for a short time.
+   Close the dialog and click Play again.
+
+2. **H.265 without hardware decoding** — BC500 records in H.265 by default.
+   ```
+   # Check if hardware decoding is working:
+   mpv --hwdec=auto <stream-url>
+   ```
+   If it fails, try forcing H.264 in Surveillance Station:
+   *Surveillance Station → IP Camera → Edit → Video → Codec → H.264*
+
+3. **mpv cannot find the codec** — Ensure full codec support is installed:
+   ```bash
+   sudo apt install ubuntu-restricted-extras
+   # or specifically:
+   sudo apt install libavcodec-extra
+   ```
+
+4. **AppImage codec isolation** — The AppImage bundles its own libraries.
+   If running via AppImage and codecs are missing, rebuild the AppImage after
+   installing the missing libs, or use the pip-installed version instead.
+
+---
+
+### Testing H.264 Instead of H.265 (BC500)
+
+1. In Surveillance Station web UI, go to *IP Camera → [camera name] → Edit*
+2. Under *Video* tab, set **Codec** to **H.264**
+3. Save and wait for the camera to reconnect
+4. Test live view and recording playback in the client
+
+H.264 has wider software decoder support and uses less CPU on older hardware.
+H.265 is more efficient at the same quality but requires hardware decoding on
+most systems.
+
+---
+
+### Download Fails: "Server returned HTML page"
+
+**Cause:** The session expired between the time you logged in and tried to
+download. Synology DSM redirects expired sessions to the login page.
+
+**Fix:** Close the app, reopen it, log in again, then retry the download.
+
+---
+
+### Download Fails: "API returned error code 105"
+
+Error code 105 = *Insufficient user privilege*.
+
+The logged-in account does not have permission to download recordings.
+Ask a Surveillance Station administrator to grant the account download access:
+*Surveillance Station → User Privilege → [user] → Recording → Allow download*
+
+---
+
+### Segmentation Fault
+
+A segfault in the mpv/OpenGL rendering path usually means:
+- A version mismatch between python-mpv, libmpv, and the OpenGL driver
+- GPU driver crash (especially with NVIDIA on Wayland)
+
+**Try:**
+```bash
+# Force X11 backend instead of Wayland
+GDK_BACKEND=x11 surveillance
+
+# Disable hardware decoding
+# Edit ~/.config/surveillance/config.toml and set hwdec = "no"
+# (or add the option manually if not present)
+```
+
+For the NVIDIA RTX 3050 on Ubuntu 24.04:
+```bash
+sudo apt install nvidia-driver-550   # or latest stable
+# Check driver version:
+nvidia-smi
+```
+
+---
+
+### Ubuntu 24.04 / AppImage Notes
+
+- The AppImage uses its own bundled Python and GTK. Do **not** mix system
+  `python3-mpv` with the AppImage.
+- If GTK theming looks wrong inside the AppImage, set:
+  ```bash
+  GTK_THEME=Adwaita surveillance.AppImage
+  ```
+- PyGObject ≥ 3.50 (GTK 4.14) is required for `Gtk.AlertDialog`. Ubuntu 24.04
+  ships PyGObject 3.48 from the system packages. The AppImage bundles a newer
+  version. If running from pip, ensure your venv has `PyGObject>=3.50`.
+
+---
+
+### Collecting Debug Logs
+
+Run the client with verbose logging:
+```bash
+surveillance --log-level debug 2>&1 | tee ~/surveillance-debug.log
+```
+
+Relevant log namespaces:
+- `surveillance.services.ws_bridge` — WebSocket bridge errors
+- `surveillance.services.recording` — recording download issues
+- `surveillance.ui.mpv_widget` — mpv option / render errors
+- `surveillance.ui.player` — playback start failures

--- a/src/surveillance/api/client.py
+++ b/src/surveillance/api/client.py
@@ -245,9 +245,24 @@ class SurveillanceAPI:
             result = resp.json()
             if not result.get("success"):
                 code = result.get("error", {}).get("code", 100)
-                raise ApiError(code)
+                syno_msg = result.get("error", {}).get("message", "")
+                raise ApiError(code, syno_msg)
+        elif "text/html" in content_type:
+            # DSM redirected to the login page — the session has expired.
+            log.warning(
+                "Download endpoint returned HTML (content-type=%s); "
+                "session may have expired",
+                content_type,
+            )
+            raise ApiError(
+                119,
+                "Server returned an HTML page — session expired or access denied",
+            )
 
         content: bytes = resp.content
+        if not content:
+            raise ApiError(100, "Server returned an empty response body")
+
         return content
 
     async def download(

--- a/src/surveillance/services/recording.py
+++ b/src/surveillance/services/recording.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import collections
+import contextlib
 import json
 import logging
 import time
@@ -134,20 +135,89 @@ def get_stream_url(api: SurveillanceAPI, rec: Recording) -> str:
     )
 
 
+def _check_download_content(data: bytes, recording_id: int) -> None:
+    """Raise ValueError if *data* looks like an error response rather than a video file.
+
+    Synology DSM may return:
+    - An empty body when the session has expired and no redirect is possible.
+    - An HTML login page (text/html) when the reverse proxy redirects instead
+      of returning a JSON error.
+    - A JSON error body when the content-type header was missed by the client.
+    Any of these would silently produce a corrupt or empty file without this check.
+    """
+    if not data:
+        raise ValueError(
+            f"Recording {recording_id}: server returned an empty response. "
+            "The session may have expired — try logging out and back in."
+        )
+
+    # Detect HTML responses (login redirect, DSM error page).
+    stripped = data[:100].lstrip()
+    if stripped[:9].lower() == b"<!doctype" or stripped[:6].lower() == b"<html>":
+        raise ValueError(
+            f"Recording {recording_id}: server returned an HTML page instead of a video file. "
+            "This usually means the session expired or the request was rejected. "
+            "Log out and log back in, then try again."
+        )
+
+    # Detect a bare JSON error that slipped past the content-type check.
+    if stripped[:1] == b"{":
+        import json as _json  # noqa: PLC0415
+
+        try:
+            obj = _json.loads(data)
+        except Exception:
+            obj = None
+        if isinstance(obj, dict) and not obj.get("success", True):
+            code = obj.get("error", {}).get("code", 0)
+            msg = obj.get("error", {}).get("message", "")
+            raise ValueError(
+                f"Recording {recording_id}: API returned error code {code}"
+                + (f" — {msg}" if msg else "")
+            )
+
+
 async def download_recording(
     api: SurveillanceAPI,
     recording_id: int,
     output_path: Path,
 ) -> Path:
-    """Download a recording to disk."""
+    """Download a recording to disk.
+
+    Validates the response content before writing so that empty or corrupt
+    files are never created.  If a partial file was created but the write
+    fails, it is removed before re-raising the exception.
+
+    Raises:
+        ValueError: API returned an error, HTML page, or empty body.
+        ApiError: Synology API error with numeric code.
+        OSError: File-system write failure (partial file is cleaned up).
+    """
+    log.debug("Downloading recording %d to %s", recording_id, output_path)
     data = await api.download(
         api="SYNO.SurveillanceStation.Recording",
         method="Download",
         version=5,
         extra_params={"id": str(recording_id)},
     )
+
+    _check_download_content(data, recording_id)
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_bytes(data)
+    try:
+        output_path.write_bytes(data)
+    except Exception:
+        # Remove any partial file so the user is not left with a 0-byte placeholder.
+        with contextlib.suppress(OSError):
+            output_path.unlink()
+        raise
+
+    log.info(
+        "Recording %d downloaded: %s (%d bytes)",
+        recording_id,
+        output_path,
+        len(data),
+    )
     return output_path
 
 

--- a/src/surveillance/services/ws_bridge.py
+++ b/src/surveillance/services/ws_bridge.py
@@ -34,6 +34,7 @@ import os
 import ssl
 import struct
 import threading
+from collections.abc import Callable
 
 import websockets.asyncio.client as ws_client
 
@@ -41,16 +42,38 @@ log = logging.getLogger(__name__)
 
 
 class WebSocketBridge:
-    """Bridge a WebSocket video stream to an in-memory pipe for mpv."""
+    """Bridge a WebSocket video stream to an in-memory pipe for mpv.
 
-    def __init__(self, ws_url: str, verify_ssl: bool, sid: str) -> None:
+    The bridge connects to a Synology WebSocket stream, strips the proprietary
+    4-byte-length framing, and writes raw Annex-B NAL units to a Unix pipe so
+    mpv can play them via fd://<read_fd>.
+
+    Connection failures (including HTTP 502) are caught, logged, and reported
+    via the optional *on_error* callback.  They never propagate as unhandled
+    exceptions.
+    """
+
+    def __init__(
+        self,
+        ws_url: str,
+        verify_ssl: bool,
+        sid: str,
+        on_error: Callable[[str], None] | None = None,
+    ) -> None:
         self._ws_url = ws_url
         self._verify_ssl = verify_ssl
         self._sid = sid
+        self._on_error = on_error
         self._read_fd: int = -1
         self._write_fd: int = -1
         self._fd_lock = threading.Lock()
         self._pump_task: asyncio.Task[None] | None = None
+        self._error: str | None = None
+
+    @property
+    def error(self) -> str | None:
+        """Most recent error message, or None if the bridge is healthy."""
+        return self._error
 
     async def start(self) -> str:
         """Create pipe, start pump task, return fd:// URL for mpv."""
@@ -89,6 +112,31 @@ class WebSocketBridge:
         # as its last 4 bytes.  Prepend it so mpv can detect NAL boundaries.
         return b"\x00\x00\x00\x01" + payload
 
+    def _classify_error(self, exc: BaseException) -> str:
+        """Return a human-readable description for a WebSocket connection error."""
+        exc_type = type(exc).__name__
+        exc_str = str(exc)
+
+        # HTTP 502 Bad Gateway: NAS overloaded, camera stream not ready, or
+        # Surveillance Station proxy rejected the connection.
+        if "502" in exc_str or "Bad Gateway" in exc_str.lower():
+            return (
+                "WebSocket connection rejected with HTTP 502 — "
+                "the NAS may be overloaded or the camera stream is not ready. "
+                "Try RTSP or MJPEG protocol as a fallback."
+            )
+
+        # Other non-2xx HTTP status during WebSocket handshake
+        if "InvalidStatus" in exc_type or "reject" in exc_str.lower():
+            return f"WebSocket handshake failed: {exc_str}"
+
+        # TLS/SSL issues
+        if "ssl" in exc_type.lower() or "SSL" in exc_str:
+            return f"WebSocket TLS error: {exc_str}"
+
+        # Generic connection failure
+        return f"WebSocket error ({exc_type}): {exc_str}"
+
     async def _pump(self) -> None:
         """Connect to the WebSocket and write video frames to the pipe.
 
@@ -97,6 +145,10 @@ class WebSocketBridge:
         video payload (Annex B H.264/H.265 NAL units) to the pipe.
         Audio frames are dropped since mpv cannot demux interleaved
         raw audio in a raw video byte stream.
+
+        Any connection failure is caught, classified, and reported via
+        the on_error callback.  The write end of the pipe is always
+        closed in the finally block so mpv sees EOF and terminates cleanly.
         """
         ssl_ctx: ssl.SSLContext | bool | None = None
         if self._ws_url.startswith("wss://"):
@@ -126,8 +178,15 @@ class WebSocketBridge:
                             await asyncio.to_thread(os.write, self._write_fd, payload)
         except (asyncio.CancelledError, BrokenPipeError):
             log.debug("WebSocket bridge cancelled")
-        except Exception:
-            log.exception("WebSocket bridge error")
+        except Exception as exc:
+            error_msg = self._classify_error(exc)
+            log.error("surveillance.services.ws_bridge: %s", error_msg)  # noqa: TRY400
+            self._error = error_msg
+            if self._on_error is not None:
+                try:
+                    self._on_error(error_msg)
+                except Exception:
+                    log.debug("ws_bridge on_error callback raised", exc_info=True)
         finally:
             self._close_write_fd()
 

--- a/src/surveillance/ui/mpv_widget.py
+++ b/src/surveillance/ui/mpv_widget.py
@@ -85,11 +85,36 @@ def _get_gl_proc_address(_ctx: ctypes.c_void_p, name: bytes) -> int:
     return 0
 
 
+def safe_set_mpv_option(player: Any, name: str, value: Any) -> bool:
+    """Set an mpv property, catching any type or value errors.
+
+    python-mpv uses mpv_set_property_string for __setitem__, which means integer 0
+    becomes b'0' — a string that mpv rejects for options expecting INT64 format (e.g.
+    demuxer-lavf-probesize, container-fps-override). This wrapper swallows those errors
+    so a bad option never crashes the application.
+
+    Returns True if the option was set successfully.
+    """
+    try:
+        player[name] = value
+    except (TypeError, ValueError) as e:
+        log.warning("mpv option %r = %r rejected (%s): %s", name, value, type(e).__name__, e)
+        return False
+    except Exception as e:
+        log.warning("mpv option %r = %r failed (%s): %s", name, value, type(e).__name__, e)
+        return False
+    else:
+        return True
+
+
 class MpvGLArea(Gtk.GLArea):
     """GTK4 GLArea widget that renders mpv video via OpenGL.
 
     Each instance has its own mpv player and render context.
     Works on both X11 and Wayland without wid embedding.
+
+    Use play_live() for live camera streams (low-latency profile)
+    and play_recording() for stored recordings (stability profile).
     """
 
     def __init__(self, tls_verify: bool = True) -> None:
@@ -100,6 +125,7 @@ class MpvGLArea(Gtk.GLArea):
         self._initialized = False
         self._render_pending = False
         self._tls_verify = tls_verify
+        self._low_latency: bool = False  # stored so _on_realize can apply correct profile
 
         self.set_auto_render(False)
         self.set_hexpand(True)
@@ -148,8 +174,9 @@ class MpvGLArea(Gtk.GLArea):
             self._ctx.update_cb = self._mpv_update_cb
             self._initialized = True
 
-            # If URL was set before realization, start playing
+            # If URL was set before realization, apply options and start playing
             if self._url:
+                self._apply_playback_options()
                 self._mpv.play(self._url)
 
         except Exception:
@@ -223,36 +250,70 @@ class MpvGLArea(Gtk.GLArea):
         elif loglevel == "warn":
             log.warning("mpv [%s]: %s", component, message.strip())
 
+    def _apply_playback_options(self) -> None:
+        """Apply buffering/latency options to mpv based on the current playback mode.
+
+        Called both from play() (when already realized) and from _on_realize()
+        (when play() was called before the widget was shown).
+
+        All options are set via safe_set_mpv_option() so a rejected option
+        never crashes the application — it is logged as a warning instead.
+        """
+        if not self._mpv:
+            return
+
+        if self._low_latency:
+            # Live view: minimise latency, short buffer, best-effort frame timing.
+            # demuxer-lavf-probesize=32 and container-fps-override=25 are
+            # non-zero integers accepted by mpv's string-based property API.
+            safe_set_mpv_option(self._mpv, "cache", "no")
+            safe_set_mpv_option(self._mpv, "demuxer-max-bytes", "512KiB")
+            safe_set_mpv_option(self._mpv, "demuxer-readahead-secs", 0)
+            safe_set_mpv_option(self._mpv, "demuxer-lavf-analyzeduration", 0)
+            safe_set_mpv_option(self._mpv, "demuxer-lavf-probesize", 32)
+            safe_set_mpv_option(self._mpv, "correct-pts", False)
+            safe_set_mpv_option(self._mpv, "untimed", True)
+            safe_set_mpv_option(self._mpv, "container-fps-override", 25)
+        else:
+            # Recording playback: prioritise stability and correct timing.
+            # Omit demuxer-lavf-probesize and container-fps-override entirely so
+            # mpv uses its own defaults (5 MB probe / auto FPS).  Setting either
+            # of these to 0 causes python-mpv to pass b'0' (string format) which
+            # mpv rejects for INT64/float options with a TypeError.
+            safe_set_mpv_option(self._mpv, "cache", "auto")
+            safe_set_mpv_option(self._mpv, "demuxer-max-bytes", "150MiB")
+            safe_set_mpv_option(self._mpv, "demuxer-readahead-secs", 2)
+            safe_set_mpv_option(self._mpv, "correct-pts", True)
+            safe_set_mpv_option(self._mpv, "untimed", False)
+
     def play(self, url: str, *, low_latency: bool = False) -> None:
         """Start playing a stream URL.
 
+        Prefer play_live() or play_recording() for clearer intent.
         When *low_latency* is True, disable caching and read-ahead so the
         stream plays in near real-time (used for WebSocket pipe bridges).
         """
         self._url = url
+        self._low_latency = low_latency
         if self._initialized and self._mpv:
             try:
-                if low_latency:
-                    self._mpv["cache"] = "no"
-                    self._mpv["demuxer-max-bytes"] = "512KiB"
-                    self._mpv["demuxer-readahead-secs"] = 0
-                    self._mpv["demuxer-lavf-analyzeduration"] = 0
-                    self._mpv["demuxer-lavf-probesize"] = 32
-                    self._mpv["correct-pts"] = False
-                    self._mpv["untimed"] = True
-                    self._mpv["container-fps-override"] = 25
-                else:
-                    self._mpv["cache"] = "auto"
-                    self._mpv["demuxer-max-bytes"] = "150MiB"
-                    self._mpv["demuxer-readahead-secs"] = 1
-                    self._mpv["demuxer-lavf-analyzeduration"] = 0  # ffmpeg default
-                    self._mpv["demuxer-lavf-probesize"] = 0  # ffmpeg default
-                    self._mpv["correct-pts"] = True
-                    self._mpv["untimed"] = False
-                    self._mpv["container-fps-override"] = 0
+                self._apply_playback_options()
                 self._mpv.play(url)
             except Exception:
                 log.exception("Failed to play %s", url)
+
+    def play_live(self, url: str) -> None:
+        """Start a live camera stream with the low-latency profile."""
+        self.play(url, low_latency=True)
+
+    def play_recording(self, url: str) -> None:
+        """Start recording playback with the stability-focused profile.
+
+        Uses conservative buffering and lets mpv auto-detect format parameters,
+        avoiding the low-latency settings that can cause crashes or glitches
+        with stored recordings served over HTTPS.
+        """
+        self.play(url, low_latency=False)
 
     def stop(self) -> None:
         """Stop playback."""

--- a/src/surveillance/ui/player.py
+++ b/src/surveillance/ui/player.py
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# How long to wait for mpv to produce a video frame before declaring failure.
+_PLAYBACK_START_TIMEOUT_MS = 7000
+
 
 class PlayerDialog(Gtk.Window):
     """Recording playback window with transport controls."""
@@ -55,6 +58,8 @@ class PlayerDialog(Gtk.Window):
         self.app = app
         self.recording = recording
         self._tick_id: int = 0
+        self._playback_check_id: int = 0
+        self._stream_url: str = ""
 
         start = datetime.fromtimestamp(recording.start_time)
         self.set_title(f"{recording.camera_name} - {start:%Y-%m-%d %H:%M:%S}")
@@ -69,6 +74,16 @@ class PlayerDialog(Gtk.Window):
         self.player = MpvGLArea(tls_verify=verify_ssl)
         self.player.set_vexpand(True)
         main_box.append(self.player)
+
+        # Status bar shown while loading / on error
+        self._status_label = Gtk.Label(label="")
+        self._status_label.add_css_class("dim-label")
+        self._status_label.add_css_class("caption")
+        self._status_label.set_margin_start(8)
+        self._status_label.set_margin_top(2)
+        self._status_label.set_xalign(0)
+        self._status_label.set_visible(False)
+        main_box.append(self._status_label)
 
         # Transport controls
         controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
@@ -130,16 +145,77 @@ class PlayerDialog(Gtk.Window):
         self._start_playback()
 
     def _start_playback(self) -> None:
-        """Get stream URL and start playback."""
+        """Get stream URL and start playback using the recording stability profile."""
         if not self.app.api:
             return
         url = get_stream_url(self.app.api, self.recording)
+        self._stream_url = url
+        log.debug(
+            "Recording stream URL for camera=%s id=%d: %.120s",
+            self.recording.camera_name,
+            self.recording.id,
+            url,
+        )
+        self._set_status("Loading…")
         self._on_stream_url(url)
 
     def _on_stream_url(self, url: str) -> None:
-        self.player.play(url)
+        # Use the recording-specific profile: stable buffering, auto FPS detection,
+        # no low-latency flags that can cause mpv option crashes.
+        self.player.play_recording(url)
         self.player.set_volume(50)
         self._tick_id = GLib.timeout_add(500, self._update_position)
+        # Schedule a single check to detect playback that never starts.
+        self._playback_check_id = GLib.timeout_add(
+            _PLAYBACK_START_TIMEOUT_MS, self._check_playback_started
+        )
+
+    def _check_playback_started(self) -> bool:
+        """One-shot: if mpv hasn't produced a frame yet, show an error."""
+        self._playback_check_id = 0
+        if self.player.time_pos is None:
+            cam = self.recording.camera_name
+            log.warning(
+                "Recording playback did not start within %dms — "
+                "camera=%s rec_id=%d url=%.80s",
+                _PLAYBACK_START_TIMEOUT_MS,
+                cam,
+                self.recording.id,
+                self._stream_url,
+            )
+            self._set_status("Playback failed — see error dialog")
+            self._show_error(
+                "Playback Failed",
+                f"The recording from camera '{cam}' could not be played.\n\n"
+                "Possible causes:\n"
+                "• The stream URL may have expired — close and reopen this dialog\n"
+                "• The recording format (H.265/HEVC) may need hardware decoding\n"
+                "• mpv cannot parse this stream type\n\n"
+                "You can try downloading the recording instead.",
+            )
+        else:
+            self._set_status("")
+        return False  # one-shot, remove the GLib source
+
+    def _set_status(self, text: str) -> None:
+        """Update the status label below the video area."""
+        if text:
+            self._status_label.set_text(text)
+            self._status_label.set_visible(True)
+        else:
+            self._status_label.set_text("")
+            self._status_label.set_visible(False)
+
+    def _show_error(self, title: str, message: str) -> None:
+        """Show a non-blocking error dialog."""
+        try:
+            dialog = Gtk.AlertDialog()
+            dialog.set_message(title)
+            dialog.set_detail(message)
+            dialog.set_buttons(["OK"])
+            dialog.show(self)
+        except Exception:
+            log.exception("Could not show error dialog: %s — %s", title, message)
 
     def _on_play_pause(self, btn: Gtk.Button) -> None:
         self.player.pause()
@@ -167,6 +243,10 @@ class PlayerDialog(Gtk.Window):
         duration = self.player.duration
 
         if pos is not None and duration is not None and duration > 0:
+            # Clear the loading status once playback is underway
+            if self._status_label.get_visible() and self._status_label.get_text() == "Loading…":
+                self._set_status("")
+
             self.position_scale.set_value(pos / duration * 100)
 
             pos_min, pos_sec = divmod(int(pos), 60)
@@ -178,5 +258,9 @@ class PlayerDialog(Gtk.Window):
     def _on_close(self, window: Gtk.Window) -> bool:
         if self._tick_id:
             GLib.source_remove(self._tick_id)
+            self._tick_id = 0
+        if self._playback_check_id:
+            GLib.source_remove(self._playback_check_id)
+            self._playback_check_id = 0
         self.player.stop()
         return False

--- a/src/surveillance/ui/recordings.py
+++ b/src/surveillance/ui/recordings.py
@@ -32,6 +32,7 @@ import contextlib
 import logging
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import gi
@@ -42,6 +43,7 @@ from gi.repository import Gdk, GdkPixbuf, Gtk  # type: ignore[import-untyped]
 
 from surveillance.api.models import Camera, Recording, decode_detection_labels
 from surveillance.services.recording import (
+    download_recording,
     fetch_recording_thumbnail,
     list_recordings,
 )
@@ -477,6 +479,17 @@ class RecordingsView(Gtk.Box):
 
         return box, picture
 
+    def _show_error_dialog(self, title: str, message: str) -> None:
+        """Show a non-blocking error alert to the user."""
+        try:
+            dialog = Gtk.AlertDialog()
+            dialog.set_message(title)
+            dialog.set_detail(message)
+            dialog.set_buttons(["OK"])
+            dialog.show(self.window)
+        except Exception:
+            log.exception("Could not show error dialog: %s — %s", title, message)
+
     def _on_play(self, btn: Gtk.Button, rec: Recording) -> None:
         log.debug("PLAY CLICKED: rec_id=%s", rec.id)
         self._play_recording(rec)
@@ -489,7 +502,7 @@ class RecordingsView(Gtk.Box):
         dialog.present()
 
     def _on_download(self, btn: Gtk.Button, rec: Recording) -> None:
-        """Download recording to disk."""
+        """Download recording to disk with progress feedback and error reporting."""
         dialog = Gtk.FileDialog()
         start = datetime.fromtimestamp(rec.start_time)
         safe_name = re.sub(r'[/\\<>:"|?*]', "_", rec.camera_name)
@@ -498,24 +511,56 @@ class RecordingsView(Gtk.Box):
         def _on_save(d: Gtk.FileDialog, result: object) -> None:
             try:
                 gfile = d.save_finish(result)
-                if gfile:
-                    path = gfile.get_path()
-                    if path:
-                        from pathlib import Path
-
-                        from surveillance.services.recording import (
-                            download_recording,
-                        )
-
-                        if self.app.api is None:
-                            return
-                        run_async(
-                            download_recording(self.app.api, rec.id, Path(path)),
-                            callback=lambda p: log.info("Downloaded to %s", p),
-                            error_callback=lambda e: log.error("Download failed: %s", e),
-                        )
             except Exception:
-                log.exception("Save dialog error")
+                # User cancelled or dialog error — nothing to do
+                return
+
+            if not gfile:
+                return
+            path = gfile.get_path()
+            if not path:
+                return
+
+            if self.app.api is None:
+                self._show_error_dialog(
+                    "Not Connected",
+                    "Cannot download: no active API session.",
+                )
+                return
+
+            # Visual feedback: disable button and show spinner icon while downloading
+            btn.set_sensitive(False)
+            btn.set_icon_name("content-loading-symbolic")
+            btn.set_tooltip_text("Downloading…")
+
+            def _on_success(p: Path) -> None:
+                btn.set_sensitive(True)
+                btn.set_icon_name("document-save-symbolic")
+                btn.set_tooltip_text("Download")
+                log.info("Recording %d downloaded to %s", rec.id, p)
+
+            def _on_error(exc: Exception) -> None:
+                btn.set_sensitive(True)
+                btn.set_icon_name("document-save-symbolic")
+                btn.set_tooltip_text("Download")
+                log.error(
+                    "Download failed: camera=%s rec_id=%d error=%s",
+                    rec.camera_name,
+                    rec.id,
+                    exc,
+                )
+                self._show_error_dialog(
+                    "Download Failed",
+                    f"Could not download recording from camera '{rec.camera_name}'.\n\n"
+                    f"{exc}\n\n"
+                    "Check the application log for details.",
+                )
+
+            run_async(
+                download_recording(self.app.api, rec.id, Path(path)),
+                callback=_on_success,
+                error_callback=_on_error,
+            )
 
         dialog.save(self.window, None, _on_save)
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -432,3 +432,256 @@ class TestRecordingService:
             assert call_kwargs[1]["extra_params"]["toTime"] == "1700086400"
             assert call_kwargs[1]["extra_params"]["offset"] == "100"
             assert call_kwargs[1]["extra_params"]["limit"] == "20"
+
+
+class TestDownloadRecordingValidation:
+    """Tests for download_recording response validation."""
+
+    @pytest.mark.asyncio
+    async def test_empty_response_raises(self, api: SurveillanceAPI, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from surveillance.services.recording import download_recording
+
+        out = Path(str(tmp_path)) / "out.mp4"
+        with (
+            patch.object(api, "download", new_callable=AsyncMock, return_value=b""),
+            pytest.raises(ValueError, match="empty response"),
+        ):
+            await download_recording(api, 1, out)
+        assert not out.exists()
+
+    @pytest.mark.asyncio
+    async def test_html_doctype_response_raises(
+        self, api: SurveillanceAPI, tmp_path: object
+    ) -> None:
+        from pathlib import Path
+
+        from surveillance.services.recording import download_recording
+
+        html = b"<!doctype html><html><body>Login</body></html>"
+        out = Path(str(tmp_path)) / "out.mp4"
+        with (
+            patch.object(api, "download", new_callable=AsyncMock, return_value=html),
+            pytest.raises(ValueError, match="HTML page"),
+        ):
+            await download_recording(api, 1, out)
+        assert not out.exists()
+
+    @pytest.mark.asyncio
+    async def test_html_tag_response_raises(
+        self, api: SurveillanceAPI, tmp_path: object
+    ) -> None:
+        from pathlib import Path
+
+        from surveillance.services.recording import download_recording
+
+        html = b"<html><body>Login</body></html>"
+        out = Path(str(tmp_path)) / "out.mp4"
+        with (
+            patch.object(api, "download", new_callable=AsyncMock, return_value=html),
+            pytest.raises(ValueError, match="HTML page"),
+        ):
+            await download_recording(api, 1, out)
+
+    @pytest.mark.asyncio
+    async def test_json_error_body_raises(self, api: SurveillanceAPI, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from surveillance.services.recording import download_recording
+
+        json_err = b'{"success":false,"error":{"code":105}}'
+        out = Path(str(tmp_path)) / "out.mp4"
+        with (
+            patch.object(api, "download", new_callable=AsyncMock, return_value=json_err),
+            pytest.raises(ValueError, match="error code 105"),
+        ):
+            await download_recording(api, 1, out)
+        assert not out.exists()
+
+    @pytest.mark.asyncio
+    async def test_successful_download_writes_file(
+        self, api: SurveillanceAPI, tmp_path: object
+    ) -> None:
+        from pathlib import Path
+
+        from surveillance.services.recording import download_recording
+
+        # Minimal ftyp-box header so it looks like a real MP4
+        video_data = b"\x00\x00\x00\x18ftyp" + b"isom" + b"\x00" * 8
+        out = Path(str(tmp_path)) / "recording.mp4"
+        with patch.object(api, "download", new_callable=AsyncMock, return_value=video_data):
+            result = await download_recording(api, 42, out)
+        assert result == out
+        assert out.exists()
+        assert out.read_bytes() == video_data
+
+    @pytest.mark.asyncio
+    async def test_write_error_cleans_up_file(
+        self, api: SurveillanceAPI, tmp_path: object
+    ) -> None:
+        from pathlib import Path
+        from unittest.mock import patch as _patch
+
+        from surveillance.services.recording import download_recording
+
+        video_data = b"\x00\x00\x00\x18ftyp" + b"\x00" * 12
+        out = Path(str(tmp_path)) / "recording.mp4"
+        with (
+            patch.object(api, "download", new_callable=AsyncMock, return_value=video_data),
+            _patch.object(Path, "write_bytes", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            await download_recording(api, 42, out)
+        assert not out.exists()
+
+
+class TestMpvSafeSetOption:
+    """Tests for safe_set_mpv_option() without requiring a real mpv instance.
+
+    These tests import from surveillance.ui.mpv_widget which in turn imports
+    GTK4 via gi.repository.  They are skipped automatically in environments
+    where GTK4 (PyGObject + C extension) is not installed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _require_gtk(self) -> None:
+        try:
+            import gi  # noqa: F401
+
+            gi.require_version("Gtk", "4.0")
+            from gi.repository import Gtk  # noqa: F401
+        except Exception:
+            pytest.skip("GTK4 not available in this environment")
+
+    def test_normal_set_succeeds(self) -> None:
+        from unittest.mock import MagicMock
+
+        from surveillance.ui.mpv_widget import safe_set_mpv_option
+
+        mock_player = MagicMock()
+        result = safe_set_mpv_option(mock_player, "cache", "no")
+        assert result is True
+        mock_player.__setitem__.assert_called_once_with("cache", "no")
+
+    def test_type_error_returns_false_without_raising(self) -> None:
+        from unittest.mock import MagicMock
+
+        from surveillance.ui.mpv_widget import safe_set_mpv_option
+
+        mock_player = MagicMock()
+        mock_player.__setitem__ = MagicMock(
+            side_effect=TypeError(
+                "Tried to get/set mpv property using wrong format, "
+                "or passed invalid value\noptions/demuxer-lavf-probesize\nvalue: b'0'"
+            )
+        )
+        result = safe_set_mpv_option(mock_player, "demuxer-lavf-probesize", 0)
+        assert result is False  # no crash, just False
+
+    def test_value_error_returns_false_without_raising(self) -> None:
+        from unittest.mock import MagicMock
+
+        from surveillance.ui.mpv_widget import safe_set_mpv_option
+
+        mock_player = MagicMock()
+        mock_player.__setitem__ = MagicMock(side_effect=ValueError("bad value"))
+        result = safe_set_mpv_option(mock_player, "container-fps-override", 0)
+        assert result is False
+
+    def test_arbitrary_exception_returns_false_without_raising(self) -> None:
+        from unittest.mock import MagicMock
+
+        from surveillance.ui.mpv_widget import safe_set_mpv_option
+
+        mock_player = MagicMock()
+        mock_player.__setitem__ = MagicMock(side_effect=RuntimeError("mpv died"))
+        result = safe_set_mpv_option(mock_player, "untimed", True)
+        assert result is False
+
+
+class TestWebSocketBridgeErrors:
+    """Tests for WebSocketBridge error handling without a real WebSocket server."""
+
+    @pytest.mark.asyncio
+    async def test_connection_error_calls_on_error_callback(self) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        from surveillance.services.ws_bridge import WebSocketBridge
+
+        errors: list[str] = []
+        bridge = WebSocketBridge(
+            "wss://192.0.2.1/stream",  # TEST-NET address, guaranteed to fail
+            verify_ssl=False,
+            sid="test-sid",
+            on_error=errors.append,
+        )
+
+        with patch(
+            "websockets.asyncio.client.connect",
+            side_effect=OSError("Connection refused"),
+        ):
+            await bridge.start()
+            # Give the pump task time to run and fail
+            import asyncio
+
+            await asyncio.sleep(0.05)
+            await bridge.stop()
+
+        assert bridge.error is not None
+        assert len(errors) == 1
+
+    @pytest.mark.asyncio
+    async def test_http_502_classified_correctly(self) -> None:
+        from unittest.mock import patch
+
+        from surveillance.services.ws_bridge import WebSocketBridge
+
+        errors: list[str] = []
+        bridge = WebSocketBridge(
+            "wss://192.0.2.1/stream",
+            verify_ssl=False,
+            sid="test-sid",
+            on_error=errors.append,
+        )
+
+        # Simulate an InvalidStatus-like error message containing "502"
+        with patch(
+            "websockets.asyncio.client.connect",
+            side_effect=Exception("server rejected WebSocket connection: HTTP 502"),
+        ):
+            await bridge.start()
+            import asyncio
+
+            await asyncio.sleep(0.05)
+            await bridge.stop()
+
+        assert bridge.error is not None
+        assert "502" in bridge.error
+
+    @pytest.mark.asyncio
+    async def test_no_on_error_does_not_crash(self) -> None:
+        """Bridge with no on_error callback should still handle errors gracefully."""
+        from unittest.mock import patch
+
+        from surveillance.services.ws_bridge import WebSocketBridge
+
+        bridge = WebSocketBridge(
+            "wss://192.0.2.1/stream",
+            verify_ssl=False,
+            sid="test-sid",
+            # no on_error
+        )
+
+        with patch(
+            "websockets.asyncio.client.connect",
+            side_effect=OSError("Connection refused"),
+        ):
+            await bridge.start()
+            import asyncio
+
+            await asyncio.sleep(0.05)
+            await bridge.stop()
+
+        # Just verify no exception propagated and error is recorded
+        assert bridge.error is not None


### PR DESCRIPTION
…t errors

MÅL 1 — mpv crashes:
- Add safe_set_mpv_option() that catches TypeError/ValueError from python-mpv's string-based property setter (the root cause of the crash: integer 0 becomes b'0' which libmpv rejects for INT64 options like demuxer-lavf-probesize).
- Remove demuxer-lavf-probesize=0 and container-fps-override=0 from the recording playback profile; let mpv use its own sensible defaults instead.
- Store _low_latency flag so _on_realize() applies the correct option profile even when play() is called before the GLArea widget is realized.

MÅL 2 — separate Live View and recording playback profiles:
- Add play_live(url) → low-latency profile (32-byte probe, 512 KiB buffer).
- Add play_recording(url) → stability profile (150 MiB buffer, correct-pts, no untimed/container-fps-override hacks).
- PlayerDialog now calls play_recording() instead of plain play().

MÅL 3 — fallback and error display in PlayerDialog:
- Add _status_label below the video area (shows "Loading…" / error text).
- Schedule a 7-second one-shot check; if time_pos is still None, show a Gtk.AlertDialog with actionable troubleshooting hints and log the URL.
- Cancel the check timer on dialog close to avoid stale callbacks.

MÅL 4 — WebSocket bridge robustness:
- Add on_error: Callable[[str], None] | None callback parameter.
- Add error property so callers can query the last failure reason.
- Classify HTTP 502, handshake failures, and TLS errors separately with human-readable messages; log at ERROR level without crashing.
- All paths (cancel, broken pipe, connection error) reach finally → write-fd close.

MÅL 5 — download validation and error reporting:
- _check_download_content() in recording.py raises ValueError for empty body, HTML login pages (<!doctype / <html>), and bare JSON error objects.
- Partial/empty output files are deleted before re-raising write errors.
- api/client.py _raw_download() now also raises ApiError(119) on text/html content-type (DSM login-page redirect) and ApiError(100) on empty body.
- Synology error message included in ApiError when present in JSON.

MÅL 6 — UI feedback for download:
- Download button shows content-loading icon and is disabled while in flight.
- On success: button restored, path logged.
- On failure: button restored, Gtk.AlertDialog with camera name, error detail, and hint to check the log.

MÅL 7 — tests:
- TestDownloadRecordingValidation: empty, HTML doctype, HTML tag, JSON error, successful write, and write-error cleanup scenarios (6 tests, all pass).
- TestMpvSafeSetOption: TypeError, ValueError, arbitrary exception, and success cases for safe_set_mpv_option() — skip cleanly when GTK is not available.
- TestWebSocketBridgeErrors: connection error, HTTP 502 classification, and no-callback robustness (3 tests, all pass).

MÅL 8 — TROUBLESHOOTING.md:
- Recommended protocols for BC500 cameras.
- HTTP 502 diagnosis and fix steps.
- mpv option crash explanation and fix.
- H.264 vs H.265 switching guide.
- Download error codes (105, HTML page).
- Ubuntu 24.04 / AppImage / NVIDIA notes.
- How to collect debug logs.

https://claude.ai/code/session_01DYAx6sBT6nPemVJxb88PqS